### PR TITLE
Update recommended version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![nbviewer](https://github.com/jupyter/design/blob/master/logos/Badges/nbviewer_badge.svg)](https://nbviewer.jupyter.org/github/JuliaAcademy/DataScience/)
 
 # Julia for Data Science
-Prepared by [@nassarhuda](https://github.com/nassarhuda). Last updated: May 2020. Julia version used: 1.4.0
+Prepared by [@nassarhuda](https://github.com/nassarhuda). Last updated: June 2021. Julia version used: 1.6.1
 
 Accompanying videos are available at [JuliaAcademy](https://juliaacademy.com/p/julia-for-data-science).
 


### PR DESCRIPTION
Pursuant to discussion in https://stackoverflow.com/questions/68177877/need-help-resolving-typeerror-in-julia/68182821#68182821, it appears that these notebooks have actually been updated for Julia 1.6, but the readme still specifies Julia 1.4.

I can confirm that the manifest can in fact be instantiated in 1.6, consistent with the compat requirement in [Project.toml](https://github.com/JuliaAcademy/DataScience/blob/08d6cfa52992f2abe2d24dcc2660a2d1c2f56d5a/Project.toml#L56) and the description of various recent commits by @logankilpatrick.

If correct, the readme just needs to be updated, so these changes would fix #35 